### PR TITLE
Fix tested binaries list collection process

### DIFF
--- a/scripts/create_build_report.py
+++ b/scripts/create_build_report.py
@@ -112,9 +112,7 @@ def create_build_report(build_job, con):
                         tested_binaries = [row[0] + "-" + row[1] + "_gcc4" if row[0] == 'linux' else row[0] + "-" + row[1] for row in result]
                     else:
                         tested_binaries = []
-                        print("~~~~>",result)
                         for row in result:
-                            print("~~~~>",row)
                             if row.count('linux'):
                                 tested_binary = row[0] + "-" + row[1] + "_gcc4" if row[1] == 'amd64' else row[0] + "-arm64" 
                             else:

--- a/scripts/create_build_report.py
+++ b/scripts/create_build_report.py
@@ -122,8 +122,8 @@ def create_build_report(build_job, con):
                             tested_binaries.append(tested_binary)
                         print(tested_binaries)
                 else:
-                    result = con.execute(f"SELECT DISTINCT tested_platform FROM '{ ext_results }'").fetchall()
-                    tested_binaries = [row[0] for row in result]
+                    result = con.execute(f"SELECT DISTINCT nightly_build, tested_platform FROM '{ ext_results }'").fetchall()
+                    tested_binaries = [second_value for first_value, second_value in result if first_value != 'python']
                 join_list = ""
                 for binary in tested_binaries:
                     if not binary.startswith('python'):
@@ -173,7 +173,6 @@ def create_build_report(build_job, con):
             matching_files = glob.glob(py_file_name_pattern)
             py_join_list = ""
             if matching_files:
-                print("PYTHON!!!!")
                 select_py_versions = duckdb.sql(f"SELECT DISTINCT version, architecture FROM '{ py_file_name_pattern }'").fetchall()
                 tested_py_versions = [row[0] + "_" + row[1] for row in select_py_versions]
                 print(tested_py_versions)


### PR DESCRIPTION
Run was failing because of the tested binaries list was incorrectly created - for `main` it suppose to not contain `linux_arm64` which is used for the Python builds. It happened because the script looked into the `duckdb_arch` and ignored if that started with 'python', but for 'Python' builds it starts with `linux_` and that brought up the confusion into a later step, creating the wrong join list.

This PR takes into account the `nightly_build` name as well, so adds to the `tested_binaries` list all the `duckdb_arch`s except for the values whose `nightly_build` is 'python`.