### PR TITLE
 latest version tag should be hardcoded for histrionicus for now

### DIFF
--- a/scripts/verify_python_build.py
+++ b/scripts/verify_python_build.py
@@ -62,7 +62,8 @@ def verify_and_test_python_linux(file_name, extensions, nightly_build, run_id, a
             container = create_container(client, container_name, docker_image, architecture, None)
             print(f"VERIFYING BUILD SHA FOR python{ version }")
             try:
-                duckdb = "duckdb" if branch == 'main' else "duckdb==1.2,<1.3"
+                # latest version tag should be hardcoded for histrionicus for now
+                duckdb = "duckdb" if branch == 'main' else "duckdb==1.2.2,<1.3"
                 container.exec_run(f"pip install -v { duckdb } --pre --upgrade", stdout=True, stderr=True)
                 subprocess_result = container.exec_run(
                     "python -c \"import duckdb; print(duckdb.sql('SELECT source_id FROM pragma_version()').fetchone()[0])\"",


### PR DESCRIPTION
Currently Python verifying script checks agains the v1.2 release in February - because of this line:
`duckdb = "duckdb" if branch == 'main' else "duckdb==1.2,<1.3"`

To work properly the version in the left boundary for the histrionicus should be taken from the biggest git tag (1.2.2 for now). I'm just hardcoding the boundary right now to return to this later.