### PR TITLE
4808 fix failure on join list creation

### DIFF
--- a/.github/workflows/NightlyBuildsCheck.yml
+++ b/.github/workflows/NightlyBuildsCheck.yml
@@ -88,7 +88,7 @@ jobs:
     name: ${{ matrix.config.branch }} - ${{ matrix.config.nightly_build }} ${{ matrix.config.duckdb_arch }} (${{ matrix.config.runs_on }})
     needs: 
       - get-run-info
-    if: ${{ needs.get-run-info.outputs.matrix != '[]' }}
+    if: ${{ fromJson(needs.get-run-info.outputs.matrix) != '[]' }}
     strategy:
       matrix:
         config: ${{ fromJson(needs.get-run-info.outputs.matrix) }}
@@ -214,7 +214,7 @@ jobs:
   
   push-reports:
     name: Push Reports
-    if: ${{ inputs.should_publish }}
+    if: ${{ inputs.should_publish == 'true' }}
     runs-on: ubuntu-latest
     needs: 
       - get-run-info

--- a/.github/workflows/NightlyBuildsCheck.yml
+++ b/.github/workflows/NightlyBuildsCheck.yml
@@ -21,7 +21,7 @@ permissions:
   issues: write
 
 concurrency:
-  group: status-${{ github.workflow }}-${{ github.ref_name }}
+  group: status-${{ github.workflow }}-${{ inputs.branch }}
   cancel-in-progress: false
 
 env:
@@ -65,28 +65,28 @@ jobs:
         env:
           CURR_DATE: ${{ steps.curr-date.outputs.CURR_DATE }}
         run: |
-          python scripts/create_tables_and_inputs.py --branch "${{ github.ref_name }}" --event "${{ inputs.event }}"
+          python scripts/create_tables_and_inputs.py --branch "${{ inputs.branch }}" --event "${{ inputs.event }}"
 
       - name: Upload DuckDB file
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.ref_name }}_run_info_tables.duckdb
-          path: ${{ github.ref_name }}_run_info_tables.duckdb
+          name: ${{ inputs.branch }}_run_info_tables.duckdb
+          path: ${{ inputs.branch }}_run_info_tables.duckdb
       
-      - name: Upload inputs_${{ github.ref_name }}.json
+      - name: Upload inputs_${{ inputs.branch }}.json
         uses: actions/upload-artifact@v4
         with:
-          name: inputs_${{ github.ref_name }}.json
-          path: inputs_${{ github.ref_name }}.json
+          name: inputs_${{ inputs.branch }}.json
+          path: inputs_${{ inputs.branch }}.json
           if-no-files-found: ignore
 
       - name: Read JSON and create matrix
         id: set-outputs
         run: |
-          matrix=$(cat inputs_${{ github.ref_name }}.json | jq -c '.')
+          matrix=$(cat inputs_${{ inputs.branch }}.json | jq -c '.')
           echo "matrix=$matrix" >> $GITHUB_OUTPUT
           echo "***"
-          cat inputs_${{ github.ref_name }}.json
+          cat inputs_${{ inputs.branch }}.json
 
   run-tests:
     name: ${{ matrix.config.branch }} - ${{ matrix.config.nightly_build }} ${{ matrix.config.duckdb_arch }} (${{ matrix.config.runs_on }})
@@ -185,36 +185,36 @@ jobs:
           python -m pip install --upgrade pip
           pip install duckdb pandas tabulate requests
 
-      - name: Download inputs_${{ github.ref_name }}.json
+      - name: Download inputs_${{ inputs.branch }}.json
         uses: actions/download-artifact@v4
         with:
-          name: inputs_${{ github.ref_name }}.json
+          name: inputs_${{ inputs.branch }}.json
           path: .
 
       - name: Download extensions artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: ${{ github.ref_name }}_ext*
-          path: ${{ github.ref_name }}_failed_ext
+          pattern: ${{ inputs.branch }}_ext*
+          path: ${{ inputs.branch }}_failed_ext
 
       - name: Download duckdb file
         uses: actions/download-artifact@v4
         with:
-          name: ${{ github.ref_name }}_run_info_tables.duckdb
-          path: ${{ github.ref_name }}_tables
+          name: ${{ inputs.branch }}_run_info_tables.duckdb
+          path: ${{ inputs.branch }}_tables
       
       - name: Generate report
         shell: bash
         env:
           CURR_DATE: ${{ needs.get-run-info.outputs.CURR_DATE }}
         run: |
-          python scripts/create_build_report.py --branch ${{ github.ref_name }}
+          python scripts/create_build_report.py --branch ${{ inputs.branch }}
 
       - name: Upload REPORT
         uses: actions/upload-artifact@v4
         with:
-          name: REPORT-${{ github.ref_name }}
-          path: ${{ needs.get-run-info.outputs.CURR_DATE }}-${{ github.ref_name }}.md
+          name: REPORT-${{ inputs.branch }}
+          path: ${{ needs.get-run-info.outputs.CURR_DATE }}-${{ inputs.branch }}.md
   
   push-reports:
     name: Push Reports
@@ -250,13 +250,13 @@ jobs:
           git pull origin main --allow-unrelated-histories
 
           mkdir -p docs/
-          mkdir -p docs/${{ github.ref_name }}
+          mkdir -p docs/${{ inputs.branch }}
           
-          mv REPORT*/${{ needs.get-run-info.outputs.CURR_DATE }}-${{ github.ref_name }}.md docs/${{ github.ref_name }}/
+          mv REPORT*/${{ needs.get-run-info.outputs.CURR_DATE }}-${{ inputs.branch }}.md docs/${{ inputs.branch }}/
 
-          ls -lah docs/${{ github.ref_name }}
+          ls -lah docs/${{ inputs.branch }}
 
-          git add docs/${{ github.ref_name }}/${{ needs.get-run-info.outputs.CURR_DATE }}-*.md
+          git add docs/${{ inputs.branch }}/${{ needs.get-run-info.outputs.CURR_DATE }}-*.md
           git commit -m "${{ env.CI_COMMIT_MESSAGE }}"
           git push origin main
   

--- a/.github/workflows/NightlyBuildsCheck.yml
+++ b/.github/workflows/NightlyBuildsCheck.yml
@@ -12,6 +12,9 @@ on:
         type: string
       should_publish:
         type: string
+      branch: 
+        type: string
+
 
 permissions:
   contents: write

--- a/.github/workflows/NightlyBuildsCheck.yml
+++ b/.github/workflows/NightlyBuildsCheck.yml
@@ -33,6 +33,10 @@ jobs:
   get-run-info:
     name: Generate nightly build artifact json file
     runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
+      AWS_DEFAULT_REGION: us-east-2
     outputs:
       CURR_DATE: ${{ steps.curr-date.outputs.CURR_DATE }}
       matrix: ${{ steps.set-outputs.outputs.matrix }}

--- a/scripts/create_build_report.py
+++ b/scripts/create_build_report.py
@@ -37,13 +37,9 @@ REPORT_FILE = f"{ CURR_DATE }-{ branch }.md"
 
 def is_gcc4(build_job, con):
     result = con.execute(f"""
-        SELECT artifacts['name']
-        FROM (
-            SELECT unnest(artifacts) AS artifacts 
-            FROM '{ build_job.get_expected_artifact_table_name() }'
-            ) 
-        WHERE artifacts['name'] 
-        LIKE '%_gcc4%'
+        SELECT expected 
+        FROM '{ build_job.get_expected_artifact_table_name() }'
+        WHERE expected LIKE '%_gcc4%'
     """).fetchall()
     gcc_artifacts = [tuple(res.split('_')[:2]) for res in result]
     print("GCC4 artifacts found in count of ", len(gcc_artifacts))
@@ -277,8 +273,8 @@ def create_build_report(build_job, con):
         f.write(f"\n### Diff of Uploaded Artifacts\nMatched atrifact names are hidden.\n\n")
         extensions_lists = con.execute(f"""
             SELECT 
-                expected AS 'Missing or Renamed Artifacts in Release CI',
-                actual AS 'New or Renamed Artifacts in the Current CI Run'
+                expected AS 'Diff of Release Assets (from the Latest Release Notes)',
+                actual AS 'Diff of Assets from `duckdb-staging` for Current Commit'
             FROM extensions_lists ORDER BY ALL;
         """).df()
         f.write(extensions_lists.to_markdown(index=False) + "\n")

--- a/scripts/create_build_report.py
+++ b/scripts/create_build_report.py
@@ -270,7 +270,7 @@ def create_build_report(build_job, con):
             pr_f = ['- ' + pf[0] for pf in previously_failed]
             f.write('\n'.join(pr_f) + '\n')
         
-        f.write(f"\n### Diff of Uploaded Artifacts\nMatched atrifact names are hidden.\n\n")
+        f.write(f"\n### Difference Between Latest Release Assets and Staged Assets from Current Run\nMatched assets names are hidden.\n\n")
         extensions_lists = con.execute(f"""
             SELECT 
                 expected AS 'Diff of Release Assets (from the Latest Release Notes)',

--- a/scripts/create_build_report.py
+++ b/scripts/create_build_report.py
@@ -128,7 +128,7 @@ def create_build_report(build_job, con):
                         binary = binary.replace("-", "_")
                         join_list += f'i."{ binary }".concat(l."{ binary }") as "{ binary }", '
                 if len(join_list) > 0:
-                    print(join_list)
+                    print("join_list:", join_list)
                     con.execute(f"""CREATE OR REPLACE TABLE results AS (
                             SELECT *, CASE 
                                 WHEN result = 'passed' 
@@ -225,7 +225,7 @@ def create_build_report(build_job, con):
                 """).df()
                 f.write(f"\n### Extensions Summary:\n\n")
                 f.write(py_ext_results_table.to_markdown(index=False) + '\n')
-
+            
             for tested_binary in tested_binaries:
                 tested_binary = tested_binary + "_" + architecture if tested_binary == 'osx' else tested_binary.replace("-", "_")
                 # add unmatching sha

--- a/scripts/create_build_report.py
+++ b/scripts/create_build_report.py
@@ -35,6 +35,19 @@ args = parser.parse_args()
 branch = args.branch
 REPORT_FILE = f"{ CURR_DATE }-{ branch }.md"
 
+def is_gcc4(build_job, con):
+    result = con.execute(f"""
+        SELECT artifacts['name']
+        FROM (
+            SELECT unnest(artifacts) AS artifacts 
+            FROM '{ build_job.get_expected_artifact_table_name() }'
+            ) 
+        WHERE artifacts['name'] 
+        LIKE '%_gcc4%'
+    """).fetchall()
+    gcc_artifacts = [row[0] for row in result]
+    return gcc_artifacts
+
 def create_build_report(build_job, con):
     failures_count = count_consecutive_failures(build_job, con)
     select_data = con.execute(f"SELECT headSha, url, createdAt, displayTitle, number FROM '{ build_job.get_run_list_table_name() }' ORDER BY createdAt DESC").fetchone()
@@ -100,6 +113,7 @@ def create_build_report(build_job, con):
             # add summary for extensions installing and loading chiecks
             file_name_pattern = f"{ branch }_failed_ext/{ branch }_ext*/{ branch }_list_failed_ext*.csv"
             matching_files = glob.glob(file_name_pattern)
+            tested_binaries = []
             if matching_files:
                 ext_results = "extensions_checking_results"
                 con.execute(f"""
@@ -108,17 +122,21 @@ def create_build_report(build_job, con):
                     """)
                 if failures_count > 0:
                     result = con.execute(f"SELECT nightly_build, duckdb_arch FROM '{ inputs }'").fetchall()
-                    if branch == 'main':
-                        tested_binaries = [row[0] + "-" + row[1] + "_gcc4" if row[0] == 'linux' else row[0] + "-" + row[1] for row in result]
-                    else:
-                        tested_binaries = []
-                        for row in result:
-                            if row.count('linux'):
-                                tested_binary = row[0] + "-" + row[1] + "_gcc4" if row[1] == 'amd64' else row[0] + "-arm64" 
-                            else:
-                                tested_binary = row[0] + "-" + row[1]
-                            tested_binaries.append(tested_binary)
-                        print(tested_binaries)
+                    is_gcc4_artifacts = is_gcc4(build_job, con)
+                    print("is_gcc4_artifacts: ", is_gcc4_artifacts)
+                    tested_binaries = [row[0] + "-" + row[1] + "_gcc4" if row[0] + "_" + row[1] in is_gcc4_artifacts else row[0] + "-" + row[1] for row in result]
+                    # if branch == 'main':
+                    #     tested_binaries = [row[0] + "-" + row[1] for row in result]
+                    #     # tested_binaries = [row[0] + "-" + row[1] + "_gcc4" if row[0] == 'linux' else row[0] + "-" + row[1] for row in result]
+                    # else:
+                    #     tested_binaries = []
+                    #     for row in result:
+                    #         if row.count('linux'):
+                    #             tested_binary = row[0] + "-" + row[1] + "_gcc4" if row[1] == 'amd64' else row[0] + "-arm64" 
+                    #         else:
+                    #             tested_binary = row[0] + "-" + row[1]
+                    #         tested_binaries.append(tested_binary)
+                    print("tested_binaries:", tested_binaries)
                 else:
                     result = con.execute(f"SELECT DISTINCT nightly_build, tested_platform FROM '{ ext_results }'").fetchall()
                     tested_binaries = [second_value for first_value, second_value in result if first_value != 'python']
@@ -226,29 +244,32 @@ def create_build_report(build_job, con):
                 f.write(f"\n### Extensions Summary:\n\n")
                 f.write(py_ext_results_table.to_markdown(index=False) + '\n')
             
-            for tested_binary in tested_binaries:
-                tested_binary = tested_binary + "_" + architecture if tested_binary == 'osx' else tested_binary.replace("-", "_")
-                # add unmatching sha
-                file_name_pattern = f"{ branch }_failed_ext/{ branch }_ext_{ tested_binary }*/{ branch }_non_matching_sha_{ tested_binary }*.csv"
+            if len(tested_binaries) > 0:
+                for tested_binary in tested_binaries:
+                    tested_binary = tested_binary + "_" + architecture if tested_binary == 'osx' else tested_binary.replace("-", "_")
+                    # add unmatching sha
+                    file_name_pattern = f"{ branch }_failed_ext/{ branch }_ext_{ tested_binary }*/{ branch }_non_matching_sha_{ tested_binary }*.csv"
+                    matching_files = glob.glob(file_name_pattern)
+                    if matching_files:
+                        unmatched = con.execute(f"""
+                            SELECT * 
+                            FROM read_csv('{ file_name_pattern }' )
+                        """).df()
+                        f.write(f"\n#### Found unmatching versions:\n\n")
+                        f.write(unmatched.to_markdown(index=False) + "\n")
+                # can be also in { branch }_failed_ext/
+                
+                file_name_pattern = f"{ branch }_failed_ext/{ branch }_non_matching_sha_*.csv"
                 matching_files = glob.glob(file_name_pattern)
                 if matching_files:
                     unmatched = con.execute(f"""
                         SELECT * 
-                        FROM read_csv('{ file_name_pattern }' )
+                        FROM read_csv('{file_name_pattern}', DELIM = ',', HEADER=False)
                     """).df()
                     f.write(f"\n#### Found unmatching versions:\n\n")
                     f.write(unmatched.to_markdown(index=False) + "\n")
-            # can be also in { branch }_failed_ext/
-            
-            file_name_pattern = f"{ branch }_failed_ext/{ branch }_non_matching_sha_*.csv"
-            matching_files = glob.glob(file_name_pattern)
-            if matching_files:
-                unmatched = con.execute(f"""
-                    SELECT * 
-                    FROM read_csv('{file_name_pattern}', DELIM = ',', HEADER=False)
-                """).df()
-                f.write(f"\n#### Found unmatching versions:\n\n")
-                f.write(unmatched.to_markdown(index=False) + "\n")
+            else:
+                f.write(f"\n#### No binaries got checked.\n\n")
         
         if failures_count > 0:            
             f.write(f"\n### Previously Failed (max 7 shown)\n\n")

--- a/scripts/create_build_report.py
+++ b/scripts/create_build_report.py
@@ -37,12 +37,12 @@ REPORT_FILE = f"{ CURR_DATE }-{ branch }.md"
 
 def is_gcc4(build_job, con):
     result = con.execute(f"""
-        SELECT expected 
-        FROM '{ build_job.get_expected_artifact_table_name() }'
-        WHERE expected LIKE '%_gcc4%'
+        SELECT actual 
+        FROM 'ACTUAL'
+        WHERE actual LIKE '%_gcc4%'
     """).fetchall()
     gcc_artifacts = [tuple(res.split('_')[:2]) for res in result]
-    print("GCC4 artifacts found in count of ", len(gcc_artifacts))
+    print("Count of GCC4 artifacts found in current CI run artifacts ", len(gcc_artifacts))
     return gcc_artifacts
 
 def create_build_report(build_job, con):

--- a/scripts/create_tables_and_inputs.py
+++ b/scripts/create_tables_and_inputs.py
@@ -86,7 +86,6 @@ def save_run_data_to_json_files(build_job, con, build_job_run_id):
         ]
     fetch_data(artifacts_command, build_job.get_artifacts_file_name())
     commit_sha = get_full_sha(build_job_run_id)[:10]
-    print("🦑", commit_sha)
     staging_command = [
             "aws", "s3", "ls", "--recursive", f"s3://duckdb-staging/{commit_sha}"
         ]

--- a/scripts/shared_functions.py
+++ b/scripts/shared_functions.py
@@ -44,7 +44,7 @@ class BuildJob:
         return f"{ self.build_job_name }_artifacts.json"
 
     def get_expected_artifacts_file_name(self):
-        return f"{ self.build_job_name }_expected_artifacts.json"
+        return f"{ self.build_job_name }_expected_artifacts.csv"
 
     def get_jobs_file_name(self):
         return f"{ self.build_job_name }_jobs.json"
@@ -56,6 +56,18 @@ def fetch_data(command, f_output):
         subprocess.run(command, stdout=data, stderr=True, check=True)
     except subprocess.CalledProcessError as e:
         print(f"Command failed with error: {e.stderr}")
+
+# get full commit SHA of the commit that triggered a run by run_id
+def get_full_sha(run_id):
+    gh_headSha_command = [
+        "gh", "run", "view",
+        str(run_id),
+        "--repo", GH_REPO,
+        "--json", "headSha",
+        "-q", ".headSha"
+    ]
+    full_sha = subprocess.run(gh_headSha_command, check=True, text=True, capture_output=True).stdout.strip()
+    return full_sha
 
 # create a json file with the list all nightly-build runs for current date
 def list_all_runs(con, build_job, branch, event):

--- a/scripts/verify_and_test.py
+++ b/scripts/verify_and_test.py
@@ -25,6 +25,7 @@ import textwrap
 from shared_functions import fetch_data
 from shared_functions import sha_matching
 from shared_functions import list_extensions
+from shared_functions import get_full_sha
 from verify_python_build import verify_and_test_python_linux
 
 GH_REPO = os.environ.get('GH_REPO', 'duckdb/duckdb')


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/4808 and changes how we compare InvokeCI artifacts to expected release artifacts:

1. The fix for 4808 adding `_gcc4` suffix to internal `tested_binaries` variable only if there are artifact names ending with `_gcc4` - previously it was added to almost each linux binary. 
We could just remove that suffix, but maybe it will be added again in the future, so this fix makes sure the workflow won't fail in that case.

2. Previously, there was a hardcoded release CI run ID to fetch expected artifacts from the Release CI run. Now we use `gh cli` to fetch Release Assets directly, avoiding the need for a hardcoded run ID.
Since Release Assets don’t match InvokeCI artifacts directly, as suggested by @carlopi , we now compare InvokeCI outputs with the contents of the `duckdb-staging` S3 bucket instead (requires AWS credentials for S3 access).