### PR TITLE
Minor fixes of the report

### DIFF
--- a/scripts/create_build_report.py
+++ b/scripts/create_build_report.py
@@ -274,7 +274,7 @@ def create_build_report(build_job, con):
         extensions_lists = con.execute(f"""
             SELECT 
                 expected AS 'Diff of Release Assets (from the Latest Release Notes)',
-                actual AS 'Diff of Assets from `duckdb-staging` for Current Commit'
+                actual AS 'Diff of Assets from 'duckdb-staging' for Current Commit'
             FROM extensions_lists ORDER BY ALL;
         """).df()
         f.write(extensions_lists.to_markdown(index=False) + "\n")

--- a/scripts/create_tables_and_inputs.py
+++ b/scripts/create_tables_and_inputs.py
@@ -90,7 +90,7 @@ def save_run_data_to_json_files(build_job, con, build_job_run_id):
     # get staged assets for run commit
     commit_sha = get_full_sha(build_job_run_id)[:10]
     staging_command = [
-            "aws", "s3", "ls", "--recursive", f"s3://duckdb-staging/{commit_sha}"
+            "aws", "s3", "ls", "--recursive", f"s3://duckdb-staging/{commit_sha}/{GH_REPO}/github_release"
         ]
     fetch_data(staging_command, 'staging.csv')
     # get assets list from latest release


### PR DESCRIPTION
replace ` with ' to get rid of highlightingstring surrounded with ` with black;

the list of artifacts was too long because of the path used to get them (s3://duckdb-staging/{commit_sha}), so @carlopi suggested more accurate path (s3://duckdb-staging/{commit_sha}/{GH_REPO}/github_release)