### PR TITLE
add an emoji to the report name to quickly understand the run conclusion

### DIFF
--- a/scripts/create_build_report.py
+++ b/scripts/create_build_report.py
@@ -52,7 +52,8 @@ def create_build_report(build_job, con):
     report_title = f"\n\n## { build_job.get_build_job_name() }: { run_name } #{ run_number } - Commit [{ run_sha }]({ run_url }) ({ run_date })\n"
 
     with open(REPORT_FILE, 'a') as f:
-        f.write(f"---\nlayout: post\ntitle: { CURR_DATE } - { run_sha }\nparent: { branch.upper() }\n---\n")
+        run_conclusion = "✅" if failures_count == 0 else "❌"
+        f.write(f"---\nlayout: post\ntitle: { CURR_DATE } - { run_sha } { run_conclusion }\nparent: { branch.upper() }\n---\n")
         if failures_count == 0:       
             f.write(f"{ report_title } Run succeeded\n{{: .label .label-green}}\n\n{ branch }\n{{: .label .label-yellow}}\n\n")
             f.write(f"#### Latest run: [ { run_date } ]({ run_url })\n")


### PR DESCRIPTION
Currently we can't see the run conclusion before open a report file:
<img width="758" alt="Screenshot 2025-05-16 at 15 32 38" src="https://github.com/user-attachments/assets/f2e93fbf-fead-48b0-b21f-4faef6c4c637" />

This PR adds ✅ or ❌ to the report name which should make it easier to understand it