### PR TITLE
fix push new report job

### DIFF
--- a/.github/workflows/NightlyBuildsCheck.yml
+++ b/.github/workflows/NightlyBuildsCheck.yml
@@ -270,6 +270,9 @@ jobs:
         if: ${{ github.ref_name != 'main'}}
         shell: bash
         run: |
+          report_file="docs/${{ github.ref_name }}/${{ needs.get-run-info.outputs.CURR_DATE }}-${{ github.ref_name }}.md"
           git fetch origin ${{ github.ref_name }}:${{ github.ref_name }}
-          git checkout ${{ github.ref_name }} -- docs/${{ github.ref_name }}/${{ needs.get-run-info.outputs.CURR_DATE }}-*.md
+          git checkout ${{ github.ref_name }} -- $report_file
+          git add $report_file
+          git commit -m "Adding $report_file to main"
           git push origin main


### PR DESCRIPTION
I was not adding a report file from the report branch to the main because of the file name and missing git commands