### PR TITLE
Replace hardcoded previous version tag and sha

### DIFF
--- a/.github/workflows/NightlyBuildsCheck.yml
+++ b/.github/workflows/NightlyBuildsCheck.yml
@@ -40,6 +40,8 @@ jobs:
       CURR_DATE: ${{ steps.curr-date.outputs.CURR_DATE }}
       matrix: ${{ steps.set-outputs.outputs.matrix }}
       run_id: ${{ steps.get_run_id.outputs.run_id }}
+      previous_tag: ${{ steps.get_run_id.outputs.previous_tag }}
+      previous_sha: ${{ steps.get_run_id.outputs.previous_sha }}
     steps:
       - id: curr-date
         run: echo "CURR_DATE=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
@@ -66,8 +68,9 @@ jobs:
         env:
           CURR_DATE: ${{ steps.curr-date.outputs.CURR_DATE }}
         run: |
-          run_id=$(python scripts/create_tables_and_inputs.py --branch "${{ github.ref_name }}" --event "${{ inputs.event }}")
-          echo "run_id=$run_id" >> $GITHUB_OUTPUT
+          python scripts/create_tables_and_inputs.py --branch "${{ github.ref_name }}" --event "${{ inputs.event }}"
+          # run_id=$(python scripts/create_tables_and_inputs.py --branch "${{ github.ref_name }}" --event "${{ inputs.event }}")
+          # echo "run_id=$run_id" >> $GITHUB_OUTPUT
 
       - name: Upload DuckDB file
         uses: actions/upload-artifact@v4
@@ -172,7 +175,7 @@ jobs:
           # get a run_id
           run_id=${{ needs.get-run-info.outputs.run_id }}
           # download nightly release files from GH and generate digests
-          aws s3 ls --recursive s3://duckdb-staging/71c5c07cdd/v1.3.0/${{ env.GH_REPO }}/github_release | awk '{print $4}' > release-assets.txt 
+          aws s3 ls --recursive s3://duckdb-staging/${{ needs.get-run-info.outputs.previous_sha }}/${{ needs.get-run-info.outputs.previous_tag }}/${{ env.GH_REPO }}/github_release | awk '{print $4}' > release-assets.txt 
           cat release-assets.txt
           for file_path in $(cat release-assets.txt); do 
             aws s3 cp s3://duckdb-staging/$file_path .;

--- a/scripts/create_tables_and_inputs.py
+++ b/scripts/create_tables_and_inputs.py
@@ -103,10 +103,10 @@ def save_run_data_to_json_files(build_job, con, build_job_run_id, on_tag):
     staging_command = [
             "aws", "s3", "ls", "--recursive", f"s3://duckdb-staging/{commit_sha}/{GH_REPO}/github_release"
         ]
-    get_previous_version = subprocess.check_output("git tag --sort=-creatordate | sed -n 2p", stderr=subprocess.STDOUT, shell=True)
-    biggest_version = get_previous_version if get_previous_version.startswith('v') else ""
+    previous_version_tag = subprocess.check_output(["git", "tag", "--sort=-creatordate"], text=True).splitlines()[1]
+    previous_tag = previous_version_tag if previous_version_tag.startswith('v') else ""
     staging_command_on_tag = [
-            "aws", "s3", "ls", "--recursive", f"s3://duckdb-staging/{commit_sha}/{biggest_version}/{GH_REPO}/github_release"
+            "aws", "s3", "ls", "--recursive", f"s3://duckdb-staging/{commit_sha}/{previous_tag}/{GH_REPO}/github_release"
         ]
     staging_result = run_aws_ls(staging_command)
     if staging_result.returncode != 0 or not staging_result.stdout.strip():

--- a/scripts/create_tables_and_inputs.py
+++ b/scripts/create_tables_and_inputs.py
@@ -103,8 +103,10 @@ def save_run_data_to_json_files(build_job, con, build_job_run_id, on_tag):
     staging_command = [
             "aws", "s3", "ls", "--recursive", f"s3://duckdb-staging/{commit_sha}/{GH_REPO}/github_release"
         ]
+    get_previous_version = subprocess.check_output("git tag --sort=-creatordate | sed -n 2p", stderr=subprocess.STDOUT, shell=True)
+    biggest_version = get_previous_version if get_previous_version.startswith('v') else ""
     staging_command_on_tag = [
-            "aws", "s3", "ls", "--recursive", f"s3://duckdb-staging/{commit_sha}/v1.3.0/{GH_REPO}/github_release"
+            "aws", "s3", "ls", "--recursive", f"s3://duckdb-staging/{commit_sha}/{biggest_version}/{GH_REPO}/github_release"
         ]
     staging_result = run_aws_ls(staging_command)
     if staging_result.returncode != 0 or not staging_result.stdout.strip():


### PR DESCRIPTION
We used hardcoded version tag and sha to get the list of previous release assets.

We also returned the run id from the `create_tables_and_inputs.py` script to save it in the GitHub outputs, which is not convenient when the script creates more than one value that you'd like to save into the GitHub outputs.

This PR replaces the old way of saving only one GitHub output variable with making python script do all these as many times as we have output variables to safe, like this:
```
with open(JOB_OUTPUTS_FILE, "a") as f:
        print(f"previous_tag={previous_tag}", file=f)
```

on the workflow side you need to have a GitHub output, where the value expected to be stored:
```
outputs:
      previous_tag: ${{ steps.get_run_id.outputs.previous_tag }}
```