### PR TITLE
Merge Pages structure updates from V1.4 andium

### DIFF
--- a/_sass/labels.scss
+++ b/_sass/labels.scss
@@ -23,6 +23,10 @@
   background-color: $green-200;
 }
 
+.label-gray:not(g) {
+  background-color: $gray-200;
+}
+
 .label-purple:not(g) {
   background-color: $purple-100;
 }

--- a/docs/andium.md
+++ b/docs/andium.md
@@ -1,0 +1,10 @@
+---
+title: V1.4-ANDIUM
+nav_order: 2
+---
+
+# Nightly Builds Status Reports
+v1.4-andium
+{: .label .label-purple}
+
+{:toc}

--- a/docs/histrionicus.md
+++ b/docs/histrionicus.md
@@ -1,10 +1,10 @@
 ---
 title: V1.2-HISTRIONICUS
-nav_order: 3
+nav_order: 4
 ---
 
 # Nightly Builds Status Reports
 v1.2-histrionicus
-{: .label .label-purple}
+{: .label .label-gray}
 
 {:toc}

--- a/docs/ossivalis.md
+++ b/docs/ossivalis.md
@@ -1,10 +1,10 @@
 ---
 title: V1.3-OSSIVALIS
-nav_order: 2
+nav_order: 3
 ---
 
 # Nightly Builds Status Reports
 v1.3-ossivalis
-{: .label .label-blue}
+{: .label .label-gray}
 
 {:toc}


### PR DESCRIPTION
Every time we branch new release from duckdb, we should add a new branch here. Also we should do the following:

1. `mkdir docs/<new branch name>`, e.g. `mkdir docs/v1.4-andium`
2. create for copy+paste and rename one of `.md` files in `docs` directory to create `.md` file for the new release, e.g. `docs/andium.md` - this will be a page template serving a list of the build reports for that branch
3. Change navigation order in all `docs/*.md` files as you think it will work best, remember that `main` should have always `nav_order: 1`.
4. Merge these updates to `main` - if `docs/v1.4-andium` doesn't exist, it will fail on pushing reports and will not deploy the Pages for that branch