### PR TITLE
update duckdb version installed for python build

### DIFF
--- a/scripts/verify_python_build.py
+++ b/scripts/verify_python_build.py
@@ -63,7 +63,7 @@ def verify_and_test_python_linux(file_name, extensions, nightly_build, run_id, a
             print(f"VERIFYING BUILD SHA FOR python{ version }")
             try:
                 # latest version tag should be hardcoded for release versions for now
-                duckdb = "duckdb" if branch == 'main' else "duckdb>1.3,<1.4"
+                duckdb = "duckdb" if branch == 'main' else "duckdb>1.4,<1.5"
                 container.exec_run(f"pip install -v { duckdb } --pre --upgrade", stdout=True, stderr=True)
                 subprocess_result = container.exec_run(
                     "python -c \"import duckdb; print(duckdb.sql('SELECT source_id FROM pragma_version()').fetchone()[0])\"",


### PR DESCRIPTION
We install nightly build of python client to run `INSTALL` and `LOAD` statements. With increasing of release number we should change downloaded [nightly build number as well](https://github.com/hmeriann/duckdb-build-status/blob/e2e1734c9dfe8e8c80a40ea37ead3b5248da96b2/scripts/verify_python_build.py#L66):
```
# latest version tag should be hardcoded for release versions for now
duckdb = "duckdb" if branch == 'main' else "duckdb>1.4,<1.5"
container.exec_run(f"pip install -v { duckdb } --pre --upgrade", stdout=True, stderr=True)
```