### PR TITLE
Add check of Release workflow from duckdb/duckdb-python repo to decide to run or not to run checks on Python builds

### DIFF
--- a/.github/workflows/VerifyBuild.yml
+++ b/.github/workflows/VerifyBuild.yml
@@ -116,7 +116,7 @@ jobs:
                     --runs_on ${{ inputs.runs_on }} \
                     --branch ${{ inputs.branch }}
               else
-                echo Python wasn't released tonight
+                echo "Python wasn't released tonight"
               fi
             fi
 

--- a/.github/workflows/VerifyBuild.yml
+++ b/.github/workflows/VerifyBuild.yml
@@ -104,14 +104,21 @@ jobs:
                   fi
                 fi
               fi
+            else
+              pythonRunId=$(gh run list --repo duckdb/duckdb-python --workflow Release --branch main -L 1 --json workflowDatabaseId --jq '.[].workflowDatabaseId')
+              gh run view  --repo duckdb/duckdb-python $pythonRunId > annotations
+              if grep 'Generated S3 URL' annotations; then 
+                echo "Verifying version and testing extensions..."
+                python scripts/verify_and_test.py \
+                    --nightly_build ${{ inputs.nightly_build }} \
+                    --architecture ${{ inputs.duckdb_arch }} \
+                    --run_id ${{ steps.get-run-id.outputs.RUN_ID }} \
+                    --runs_on ${{ inputs.runs_on }} \
+                    --branch ${{ inputs.branch }}
+              else
+                echo Python wasn't released tonight
+              fi
             fi
-            echo "Verifying version and testing extensions..."
-            python scripts/verify_and_test.py \
-                --nightly_build ${{ inputs.nightly_build }} \
-                --architecture ${{ inputs.duckdb_arch }} \
-                --run_id ${{ steps.get-run-id.outputs.RUN_ID }} \
-                --runs_on ${{ inputs.runs_on }} \
-                --branch ${{ inputs.branch }}
 
       - name: Upload actions for extensions
         if: always()

--- a/.github/workflows/VerifyBuild.yml
+++ b/.github/workflows/VerifyBuild.yml
@@ -105,7 +105,7 @@ jobs:
                 fi
               fi
             else
-              pythonRunId=$(gh run list --repo duckdb/duckdb-python --workflow Release --branch main -L 1 --json workflowDatabaseId --jq '.[].workflowDatabaseId')
+              pythonRunId=$(gh run list --repo duckdb/duckdb-python --workflow Release --branch main -L 1 --json databaseId --jq '.[].databaseId')
               gh run view  --repo duckdb/duckdb-python $pythonRunId > annotations
               if grep 'Generated S3 URL' annotations; then 
                 echo "Verifying version and testing extensions..."

--- a/scripts/verify_python_build.py
+++ b/scripts/verify_python_build.py
@@ -34,24 +34,9 @@ def stop_container(container, container_name):
     container.remove()
     print(f"Container '{ container_name } has stopped.")
 
-def list_builds_for_python_versions(run_id):
-    file_name = "python_run_info.md"
-    command = [
-        "gh", "run", "view",
-        "--repo", GH_REPO,
-        run_id, "-v"
-    ]
-    fetch_data(command, file_name)
-    with open(file_name, "r") as file:
-        content = file.read()
-        pattern = r"cp([0-9]+)-.*"
-        matches = sorted(set(re.findall(pattern, content)))
-        # puts a '.' after the first character: '310' => '3.10'
-        result = [word[0] + '.' + word[1:] if len(word) > 1 else word + '.' for word in matches]
-        return result
-
 def verify_and_test_python_linux(file_name, extensions, nightly_build, run_id, architecture, runs_on, full_sha, tested_platforms_file_name, branch):
-    python_versions = list_builds_for_python_versions(run_id)
+    python_versions = ['3.9', '3.10', '3.11', '3.12', '3.13']
+    print(python_versions)
     if runs_on.count("ubuntu"):
         for version in python_versions:
             print("HERE")


### PR DESCRIPTION
Since the python client is not built by InvokeCI anymore, we cannot determine the python versions to be tested based on InvokeCI logs - that's why we most likely want them to be hardcoded for now.
Also we don't wanna run checks on Python nightly builds if they weren't uploaded to PyPi tonight. So this PR adds also a check that gets Relese workflow from duckdb/duckdb-python repo overview to check if there was a build to test.